### PR TITLE
merge dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 This is a local storage engine implementation for MadFS.
+
+# TEST instruction
+- reserver enough hugepage:
+    - `echo "1024" > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages`
+    - This command reserve 1024MB page from memory (su)
+- test5: single thread test, including cross-boundary read/write, metadata restore
+    - `cargo run --example test5 ./examples/config_file.json` (sudo)
+    - Since this configuration file use memory to simulate SSD, and use local filesystem to support RocksDB, the metadata can be restored correctly(already been tested in test5), but not for the data. So an extra removal for the RocksDB directory should be played before test5.

--- a/docs/进展.md
+++ b/docs/进展.md
@@ -57,4 +57,8 @@ Problem about fuse test mentioned above remain unsolved.
 - [x] add boundary check to avoid some crash
 - [ ] todo: restore and restore test
 
-
+## 0728 record
+- [x] add restore part
+- [x] test metadata restore --- pass
+- [ ] todo: multi_thread read/write
+- [ ] todo: reliable write

--- a/mad_engine/examples/nvme.json
+++ b/mad_engine/examples/nvme.json
@@ -1,0 +1,17 @@
+{
+"subsystems": [
+{
+"subsystem": "bdev",
+"config": [
+{
+"method": "bdev_nvme_attach_controller",
+"params": {
+"trtype": "PCIe",
+"name":"Nvme0",
+"traddr":"0000:02:00.0"
+}
+}
+]
+}
+]
+}

--- a/mad_engine/examples/test1.rs
+++ b/mad_engine/examples/test1.rs
@@ -10,7 +10,7 @@ fn main() {
     event::AppOpts::new()
         .name("test1")
         .config_file(&std::env::args().nth(1).expect("expect config file"))
-        .block_on(test1_helper("mad_engine"))
+        .block_on(test1_helper("Nvme0n1"))
         .unwrap();
 }
 

--- a/mad_engine/examples/test2.rs
+++ b/mad_engine/examples/test2.rs
@@ -18,7 +18,7 @@ fn main() {
 }
 
 async fn test2_helper(name: &str) -> std::result::Result<(), EngineError> {
-    let handle = MadEngineHandle::new("data", name).await.unwrap();
+    let mut handle = MadEngineHandle::new("data", name).await.unwrap();
     handle.create("file2".to_string()).unwrap();
     info!("create file2 succeed...");
     let mut buf: Vec<u8> = vec![0u8; DATA_LEN];

--- a/mad_engine/examples/test2.rs
+++ b/mad_engine/examples/test2.rs
@@ -13,7 +13,7 @@ fn main() {
     event::AppOpts::new()
         .name("test2")
         .config_file(&std::env::args().nth(1).expect("expect config file"))
-        .block_on(test2_helper("mad_engine"))
+        .block_on(test2_helper("Nvme0n1"))
         .unwrap();
 }
 

--- a/mad_engine/examples/test3.rs
+++ b/mad_engine/examples/test3.rs
@@ -17,7 +17,7 @@ fn main() {
 }
 
 async fn test3_helper(name: &str) -> std::result::Result<(), EngineError> {
-    let handle = MadEngineHandle::new("data", name).await.unwrap();
+    let mut handle = MadEngineHandle::new("data", name).await.unwrap();
     handle.create("file3".to_string()).unwrap();
     info!("create file3 succeed...");
     let mut buf: Vec<u8> = vec![0u8; DATA_LEN];

--- a/mad_engine/examples/test3.rs
+++ b/mad_engine/examples/test3.rs
@@ -12,7 +12,7 @@ fn main() {
     event::AppOpts::new()
         .name("test3")
         .config_file(&std::env::args().nth(1).expect("expect config file"))
-        .block_on(test3_helper("mad_engine"))
+        .block_on(test3_helper("Nvme0n1"))
         .unwrap();
 }
 

--- a/mad_engine/examples/test4.rs
+++ b/mad_engine/examples/test4.rs
@@ -16,7 +16,7 @@ fn main() {
 }
 
 async fn test4_helper(name: &str) -> std::result::Result<(), EngineError> {
-    let handle = MadEngineHandle::new("data", name).await.unwrap();
+    let mut handle = MadEngineHandle::new("data", name).await.unwrap();
     handle.create("file4".to_string()).unwrap();
     info!("create file4 pass...");
     let mut buf1 = vec![0u8; DATA_LEN];

--- a/mad_engine/examples/test4.rs
+++ b/mad_engine/examples/test4.rs
@@ -11,7 +11,7 @@ fn main() {
     event::AppOpts::new()
         .name("test4")
         .config_file(&std::env::args().nth(1).expect("no such config file"))
-        .block_on(test4_helper("mad_engine"))
+        .block_on(test4_helper("Nvme0n1"))
         .unwrap();
 }
 

--- a/mad_engine/examples/test5.rs
+++ b/mad_engine/examples/test5.rs
@@ -12,7 +12,7 @@ fn main() {
     event::AppOpts::new()
         .name("test5")
         .config_file(&std::env::args().nth(1).expect("no such config file"))
-        .block_on(test5_helper("mad_engine"))
+        .block_on(test5_helper("Nvme0n1"))
         .unwrap();
 }
 

--- a/mad_engine/examples/test5.rs
+++ b/mad_engine/examples/test5.rs
@@ -19,7 +19,7 @@ const DATA_LEN3: usize = 5120;
 const DATA_LEN4: usize = 6144;
 
 async fn test5_helper(name: &str) -> std::result::Result<(), EngineError> {
-    let handle = MadEngineHandle::new("data", name).await.unwrap();
+    let mut handle = MadEngineHandle::new("data", name).await.unwrap();
 
     // test1: basic create and remove test
     handle.create("file1".to_string()).unwrap();

--- a/mad_engine/examples/test5.rs
+++ b/mad_engine/examples/test5.rs
@@ -21,21 +21,19 @@ const DATA_LEN3: usize = 5120;
 const DATA_LEN4: usize = 6144;
 
 async fn test5_helper(name: &str) -> std::result::Result<(), EngineError> {
-    let handle = MadEngineHandle::new("data", name)
-        .await
-        .unwrap();
+    let mut handle = MadEngineHandle::new("data", name).await.unwrap();
 
     // test1: basic create and remove test
     handle.create("file1".to_string()).unwrap();
     handle.remove("file1".to_string()).unwrap();
-    drop(handle);
+    // drop(handle);
     info!("test1 pass...");
     std::thread::sleep(Duration::from_secs(1));
 
     // test2: basic read and write test
-    let mut handle = MadEngineHandle::new("data", name)
-        .await
-        .unwrap();
+    // let mut handle = MadEngineHandle::new("data", name)
+    //     .await
+    //     .unwrap();
     handle.create("file2".to_string()).unwrap();
     let mut buf: Vec<u8> = vec![0u8; DATA_LEN2];
     for i in 0..DATA_LEN2 {
@@ -56,14 +54,14 @@ async fn test5_helper(name: &str) -> std::result::Result<(), EngineError> {
         }
     }
     handle.remove("file2".to_string()).unwrap();
-    drop(handle);
+    // drop(handle);
     info!("test2 pass...");
     std::thread::sleep(Duration::from_secs(1));
 
     // test3: single read and write but cross bondary
-    let mut handle = MadEngineHandle::new("data", name)
-        .await
-        .unwrap();
+    // let mut handle = MadEngineHandle::new("data", name)
+    //     .await
+    //     .unwrap();
     let mut buf: Vec<u8> = vec![0u8; DATA_LEN3];
     for i in 0..DATA_LEN3 {
         buf[i] = i as u8;
@@ -85,14 +83,14 @@ async fn test5_helper(name: &str) -> std::result::Result<(), EngineError> {
         }
     }
     handle.remove("file3".to_string()).unwrap();
-    drop(handle);
+    // drop(handle);
     info!("test3 pass...");
     std::thread::sleep(Duration::from_secs(1));
 
     // test4: multiple read and write
-    let mut handle = MadEngineHandle::new("data", name)
-        .await
-        .unwrap();
+    // let mut handle = MadEngineHandle::new("data", name)
+    //     .await
+    //     .unwrap();
     handle.create("file4".to_string()).unwrap();
     let mut buf1 = vec![0u8; DATA_LEN4];
     for i in 0..DATA_LEN4 {

--- a/mad_engine/examples/test5.rs
+++ b/mad_engine/examples/test5.rs
@@ -1,6 +1,8 @@
 // this is an integration test for mad_engine
 // basically an aggregation of test1-4
 
+use std::time::Duration;
+
 use async_spdk::*;
 use log::*;
 use mad_engine::*;
@@ -19,14 +21,21 @@ const DATA_LEN3: usize = 5120;
 const DATA_LEN4: usize = 6144;
 
 async fn test5_helper(name: &str) -> std::result::Result<(), EngineError> {
-    let mut handle = MadEngineHandle::new("data", name).await.unwrap();
+    let handle = MadEngineHandle::new("data", name)
+        .await
+        .unwrap();
 
     // test1: basic create and remove test
     handle.create("file1".to_string()).unwrap();
     handle.remove("file1".to_string()).unwrap();
+    drop(handle);
     info!("test1 pass...");
+    std::thread::sleep(Duration::from_secs(1));
 
     // test2: basic read and write test
+    let mut handle = MadEngineHandle::new("data", name)
+        .await
+        .unwrap();
     handle.create("file2".to_string()).unwrap();
     let mut buf: Vec<u8> = vec![0u8; DATA_LEN2];
     for i in 0..DATA_LEN2 {
@@ -47,9 +56,14 @@ async fn test5_helper(name: &str) -> std::result::Result<(), EngineError> {
         }
     }
     handle.remove("file2".to_string()).unwrap();
+    drop(handle);
     info!("test2 pass...");
+    std::thread::sleep(Duration::from_secs(1));
 
     // test3: single read and write but cross bondary
+    let mut handle = MadEngineHandle::new("data", name)
+        .await
+        .unwrap();
     let mut buf: Vec<u8> = vec![0u8; DATA_LEN3];
     for i in 0..DATA_LEN3 {
         buf[i] = i as u8;
@@ -71,9 +85,14 @@ async fn test5_helper(name: &str) -> std::result::Result<(), EngineError> {
         }
     }
     handle.remove("file3".to_string()).unwrap();
+    drop(handle);
     info!("test3 pass...");
+    std::thread::sleep(Duration::from_secs(1));
 
     // test4: multiple read and write
+    let mut handle = MadEngineHandle::new("data", name)
+        .await
+        .unwrap();
     handle.create("file4".to_string()).unwrap();
     let mut buf1 = vec![0u8; DATA_LEN4];
     for i in 0..DATA_LEN4 {

--- a/mad_engine/src/common.rs
+++ b/mad_engine/src/common.rs
@@ -1,12 +1,8 @@
 use crate::utils::*;
-use async_spdk::blob::{BlobId as SBlobId};
+use async_spdk::blob::BlobId as SBlobId;
 use rocksdb::DB;
 use serde::{Deserialize, Serialize};
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    sync::Arc,
-};
+use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
 #[derive(Debug)]
 pub struct Chunk {
@@ -67,9 +63,10 @@ impl Chunk {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MadEngine {
     // global free list
-    pub free_list: HashMap<SBlobId, BitMap>,
+    // pub(crate) free_list: HashMap<SBlobId, BitMap>,
+    pub(crate) free_list: HashMap<String, BitMap>,
     // allocated blobs
-    pub blobs: Vec<SBlobId>,
+    pub(crate) blobs: Vec<SBlobId>,
     // information about lower device
     pub(crate) device: DeviceInfo,
 }

--- a/mad_engine/src/common.rs
+++ b/mad_engine/src/common.rs
@@ -1,20 +1,12 @@
-use crate::error::{EngineError, Result};
-use crate::{utils::*, DeviceEngine};
-use async_spdk::blob::{self, BlobId as SBlobId};
-use async_spdk::env::DmaBuf;
-use async_spdk::event;
-use rocksdb::{DBWithThreadMode, SingleThreaded, DB};
-use rusty_pool::ThreadPool;
+use crate::utils::*;
+use async_spdk::blob::{BlobId as SBlobId};
+use rocksdb::DB;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 use std::{
     cell::RefCell,
     collections::HashMap,
-    path::Path,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
-
-const PAGE_SIZE: u64 = 0x1000;
 
 #[derive(Debug)]
 pub struct Chunk {
@@ -26,24 +18,24 @@ pub struct Chunk {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChunkMeta {
     // size in bytes
-    size: u64,
+    pub(crate) size: u64,
     // page -> (BlobId, offset)
-    location: Option<HashMap<u64, PagePos>>,
+    pub(crate) location: Option<HashMap<u64, PagePos>>,
     // checksum algorithm type
-    csum_type: String,
-    csum_data: Vec<u32>,
+    pub(crate) csum_type: String,
+    pub(crate) csum_data: Vec<u32>,
 }
 
 // structure used for stat
 pub struct StatMeta {
-    size: u64,
-    csum_type: String,
+    pub(crate) size: u64,
+    pub(crate) csum_type: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct PagePos {
-    bid: SBlobId,
-    offset: u64,
+    pub(crate) bid: SBlobId,
+    pub(crate) offset: u64,
 }
 
 impl Default for ChunkMeta {
@@ -72,525 +64,14 @@ impl Chunk {
     }
 }
 
-pub struct MadEngineHandle {
-    db: Arc<DB>,
-    device_engine: Arc<DeviceEngine>,
-    mad_engine: Arc<Mutex<MadEngine>>,
-    pool: ThreadPool,
-}
-
-impl MadEngineHandle {
-    /// create or restore a madengine handle
-    pub async fn new(path: impl AsRef<Path>, device_name: &str) -> Result<Self> {
-        let db = Arc::new(DB::open_default(path).unwrap());
-        if let Some(_) = db
-            .get(Hasher::new().checksum(MAGIC.as_bytes()).to_string())
-            .unwrap()
-        {
-            return Self::restore(db, device_name).await;
-        } else {
-            return Self::create_me(db.clone(), device_name).await;
-        }
-    }
-
-    pub async fn restore(
-        db: Arc<DBWithThreadMode<SingleThreaded>>,
-        device_name: &str,
-    ) -> Result<Self> {
-        let handle = Arc::new(DeviceEngine::new(device_name).await.unwrap());
-        let pool = ThreadPool::new(NUM_THREAD, NUM_THREAD, Duration::from_secs(1));
-        let global = db
-            .get(Hasher::new().checksum(MAGIC.as_bytes()).to_string())
-            .unwrap();
-        if global.is_none() {
-            return Err(EngineError::RestoreFail);
-        }
-        let global_meta: MadEngine =
-            serde_json::from_slice(&String::from_utf8(global.unwrap()).unwrap().as_bytes())
-                .unwrap();
-        let mad_engine = Arc::new(Mutex::new(global_meta));
-        let num_init = NUM_THREAD;
-        let num_blobs = {
-            let l = mad_engine.lock().unwrap();
-            l.blobs.len()
-        };
-        for _ in 0..num_init {
-            let handle = handle.clone();
-        }
-
-        unimplemented!()
-    }
-
-    /// create basic MadEngineHandle
-    pub async fn create_me(
-        db: Arc<DBWithThreadMode<SingleThreaded>>,
-        device_name: &str,
-    ) -> Result<Self> {
-        let handle = Arc::new(DeviceEngine::new(device_name).await.unwrap());
-        let pool = ThreadPool::new(NUM_THREAD, NUM_THREAD, Duration::from_secs(1));
-        let total_cluster = handle.total_data_cluster_count().unwrap();
-        let num_init = NUM_THREAD;
-        let mad_engine = Arc::new(Mutex::new(MadEngine::new(total_cluster)));
-        for _ in 0..num_init {
-            let handle = handle.clone();
-            let blob_id = handle.create_blob(64).await.unwrap();
-            let db = db.clone();
-            let me = mad_engine.clone();
-            // do the initialization work for each thread
-            pool.spawn(async move {
-                TLS.with(move |f| {
-                    let mut br = f.borrow_mut();
-                    br.tblobs = vec![blob_id.get_id().unwrap()];
-                    br.tfree_list = HashMap::new();
-                    let bitmap = BitMap::new(BLOB_SIZE * CLUSTER_SIZE);
-                    br.tfree_list
-                        .insert(blob_id.get_id().unwrap(), bitmap.clone());
-                    let mut l = me.lock().unwrap();
-                    l.blobs.push(blob_id.get_id().unwrap());
-                    l.free_list
-                        .insert(blob_id.get_id().unwrap(), bitmap.clone());
-                    drop(l);
-                    br.db = Some(db);
-                });
-            });
-        }
-        pool.join();
-        let magic = mad_engine.lock().unwrap();
-        let global = magic.clone();
-        drop(magic);
-        db.put(
-            Hasher::new().checksum(MAGIC.as_bytes()).to_string(),
-            serde_json::to_string(&global).unwrap().as_bytes(),
-        )
-        .unwrap();
-        Ok(Self {
-            db: db.clone(),
-            device_engine: handle,
-            mad_engine,
-            pool,
-        })
-    }
-
-    /// read a chunk, this should return the read length
-    ///
-    /// TODO: check read range, return read length
-    pub async fn read(&self, name: String, offset: u64, data: &mut [u8]) -> Result<()> {
-        let len = data.len() as u64;
-        let start_page = offset / PAGE_SIZE;
-        let end_page = (offset + len - 1) / PAGE_SIZE;
-        event::spawn(async {
-            let chunk_meta = self.db.clone().get(name).unwrap();
-            if chunk_meta.is_none() {
-                return Err(EngineError::MetaNotExist);
-            }
-            let chunk_meta: ChunkMeta =
-                serde_json::from_slice(&String::from_utf8(chunk_meta.unwrap()).unwrap().as_bytes())
-                    .unwrap();
-            let size = chunk_meta.size;
-            if offset >= size || offset + len > size {
-                return Err(EngineError::ReadOutRange);
-            }
-            let poses = (start_page..=end_page)
-                .map(|p| {
-                    chunk_meta
-                        .location
-                        .clone()
-                        .unwrap()
-                        .get(&p)
-                        .unwrap()
-                        .clone()
-                })
-                .collect::<Vec<_>>();
-            let checksum_vec = chunk_meta.csum_data.clone();
-            // there should be a merger to merge succesive pages
-            let mut buf = DmaBuf::alloc((PAGE_SIZE) as usize, 0x1000);
-            let mut anchor = 0;
-            for (i, pos) in poses.iter().enumerate() {
-                self.device_engine
-                    .clone()
-                    .read(pos.offset, pos.bid, buf.as_mut())
-                    .await
-                    .unwrap();
-                if Hasher::new().checksum(buf.as_ref()) != checksum_vec[i + start_page as usize] {
-                    return Err(EngineError::CheckSumErr);
-                }
-                if i == poses.len() - 1 {
-                    let end = offset + len - 1 - end_page * PAGE_SIZE;
-                    let buffer = buf.as_ref();
-                    data[anchor..].copy_from_slice(&buffer[0..=end as usize]);
-                } else if i == 0 {
-                    let buffer = buf.as_ref();
-                    data[anchor..((start_page + 1) * PAGE_SIZE - offset) as usize]
-                        .copy_from_slice(&buffer[((offset - start_page * PAGE_SIZE) as usize)..]);
-                    anchor += ((start_page + 1) * PAGE_SIZE - offset) as usize;
-                } else {
-                    data[anchor..(anchor + PAGE_SIZE as usize)].copy_from_slice(&buf.as_ref());
-                    anchor += PAGE_SIZE as usize;
-                }
-            }
-            Ok(())
-        })
-        .await
-        .unwrap();
-        Ok(())
-    }
-
-    pub async fn write(&self, name: String, offset: u64, data: &[u8]) -> Result<()> {
-        let len = data.len() as u64;
-        let chunk_meta = self.db.clone().get(name.clone()).unwrap();
-        if chunk_meta.is_none() {
-            return Err(EngineError::MetaNotExist);
-        }
-        let mut chunk_meta: ChunkMeta =
-            serde_json::from_slice(&String::from_utf8(chunk_meta.unwrap()).unwrap().as_bytes())
-                .unwrap();
-        let size = chunk_meta.get_size();
-        if offset >= size {
-            return Err(EngineError::HoleNotAllowed);
-        }
-        let mut checksum_vec = chunk_meta.csum_data.clone();
-        let start_page = offset / PAGE_SIZE;
-        let cover_end_page = size.min(offset + len - 1) / PAGE_SIZE;
-        let end_page = (offset + len - 1) / PAGE_SIZE;
-        let mut last_page = size as i64 / PAGE_SIZE as i64;
-        if size == 0 {
-            last_page = -1;
-        }
-        let total_page_num = end_page - start_page + 1;
-        // first write
-        let poses = if size == 0 {
-            vec![]
-        } else {
-            (start_page..=cover_end_page)
-                .map(|p| {
-                    chunk_meta
-                        .location
-                        .clone()
-                        .unwrap()
-                        .get(&p)
-                        .unwrap()
-                        .clone()
-                })
-                .collect::<Vec<_>>()
-        };
-        // let poses = (start_page..=cover_end_page)
-        //     .map(|p| {
-        //         chunk_meta
-        //             .location
-        //             .clone()
-        //             .unwrap()
-        //             .get(&p)
-        //             .unwrap()
-        //             .clone()
-        //     })
-        //     .collect::<Vec<_>>();
-        // get all the new positions to write new data
-        // recycle old positions
-        let poses_copy = poses.clone();
-        let new_poses = self
-            .pool
-            .complete(async move {
-                let mut ret = vec![];
-                TLS.with(|f| {
-                    let mut br = f.borrow_mut();
-                    let mut cnt = total_page_num;
-                    while cnt > 0 {
-                        let tblobs = br.tblobs.clone();
-                        for bid in tblobs.iter() {
-                            let bm = br.tfree_list.get_mut(&bid);
-                            if bm.is_none() {
-                                break;
-                            }
-                            let bm = bm.unwrap();
-                            let idx = bm.find().unwrap();
-                            ret.push(PagePos {
-                                bid: bid.clone(),
-                                offset: idx,
-                            });
-                            bm.set(idx);
-                            cnt -= 1;
-                            if cnt == 0 {
-                                break;
-                            }
-                        }
-                    }
-                    // recycle old pages
-                    // fix bug: do a merger
-                    let mut new_blobs = vec![];
-                    for pos in poses_copy {
-                        let mut flag = false;
-                        let tblobs = br.tblobs.clone();
-                        for bid in tblobs.iter() {
-                            if *bid == pos.bid {
-                                let bm = br.tfree_list.get_mut(&bid);
-                                bm.unwrap().clear(pos.offset);
-                                flag = true;
-                                break;
-                            }
-                        }
-                        // not in the old tblobs, but maybe in the newblobs
-                        if flag == false {
-                            for bid in new_blobs.iter() {
-                                if *bid == pos.bid {
-                                    flag = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if flag == false {
-                            new_blobs.push(pos.bid);
-                            let mut bm = BitMap::new_set_ones(BLOB_SIZE * CLUSTER_SIZE);
-                            bm.clear(pos.offset);
-                            br.tfree_list.insert(pos.bid, bm);
-                        } else {
-                            let bm = br.tfree_list.get_mut(&pos.bid).unwrap();
-                            bm.clear(pos.offset);
-                        }
-                    }
-                    for new_blob in new_blobs {
-                        br.tblobs.push(new_blob);
-                    }
-                });
-                ret
-            })
-            .await_complete();
-        event::spawn(async {
-            let mut idx_anchor = 0;
-            let mut data_anchor = 0;
-            for (i, pos) in poses.iter().enumerate() {
-                let mut buf = DmaBuf::alloc((PAGE_SIZE) as usize, 0x1000);
-                // read first page
-                if i == 0 {
-                    self.device_engine
-                        .clone()
-                        .read(pos.offset, pos.bid, buf.as_mut())
-                        .await
-                        .unwrap();
-                    let buffer = buf.as_mut();
-                    buffer[(offset - start_page * PAGE_SIZE) as usize..].copy_from_slice(
-                        &data
-                            [data_anchor..(PAGE_SIZE - (offset - start_page * PAGE_SIZE)) as usize],
-                    );
-                    checksum_vec[i + start_page as usize] = Hasher::new().checksum(buffer.as_ref());
-                    self.device_engine
-                        .clone()
-                        .write(
-                            new_poses[idx_anchor].offset,
-                            new_poses[idx_anchor].bid,
-                            buffer,
-                        )
-                        .await
-                        .unwrap();
-                    idx_anchor += 1;
-                    data_anchor += (PAGE_SIZE - (offset - start_page * PAGE_SIZE)) as usize;
-                } else if i == poses.len() - 1 {
-                    // all overwrite
-                    if end_page as i64 == last_page {
-                        if size <= offset + len {
-                            let buffer = buf.as_mut();
-                            buffer.fill(0);
-                            buffer[0..(data.len() - data_anchor)]
-                                .copy_from_slice(&data[data_anchor..]);
-                            checksum_vec[i + start_page as usize] =
-                                Hasher::new().checksum(buffer.as_ref());
-                            self.device_engine
-                                .clone()
-                                .write(
-                                    new_poses[idx_anchor].offset,
-                                    new_poses[idx_anchor].bid,
-                                    buffer,
-                                )
-                                .await
-                                .unwrap();
-                            idx_anchor += 1;
-                            data_anchor = data.len();
-                        } else {
-                            self.device_engine
-                                .clone()
-                                .read(pos.offset, pos.bid, buf.as_mut())
-                                .await
-                                .unwrap();
-                            let buffer = buf.as_mut();
-                            buffer[0..(offset + len - end_page * PAGE_SIZE) as usize]
-                                .copy_from_slice(&data[data_anchor..]);
-                            checksum_vec[i + start_page as usize] =
-                                Hasher::new().checksum(buffer.as_ref());
-                            self.device_engine
-                                .clone()
-                                .write(
-                                    new_poses[idx_anchor].offset,
-                                    new_poses[idx_anchor].bid,
-                                    buffer,
-                                )
-                                .await
-                                .unwrap();
-                            idx_anchor += 1;
-                            data_anchor = data.len();
-                        }
-                    } else if last_page > end_page as i64 {
-                        self.device_engine
-                            .clone()
-                            .read(pos.offset, pos.bid, buf.as_mut())
-                            .await
-                            .unwrap();
-                        let buffer = buf.as_mut();
-                        buffer[0..(offset + len - end_page * PAGE_SIZE) as usize]
-                            .copy_from_slice(&data[data_anchor..]);
-                        checksum_vec[i + start_page as usize] =
-                            Hasher::new().checksum(buffer.as_ref());
-                        self.device_engine
-                            .clone()
-                            .write(
-                                new_poses[idx_anchor].offset,
-                                new_poses[idx_anchor].bid,
-                                buffer,
-                            )
-                            .await
-                            .unwrap();
-                        idx_anchor += 1;
-                        data_anchor = data.len();
-                    } else {
-                        self.device_engine
-                            .clone()
-                            .write(
-                                new_poses[idx_anchor].offset,
-                                new_poses[idx_anchor].bid,
-                                &data[data_anchor..(data_anchor + PAGE_SIZE as usize)],
-                            )
-                            .await
-                            .unwrap();
-                        checksum_vec[i + start_page as usize] = Hasher::new()
-                            .checksum(&data[data_anchor..(data_anchor + PAGE_SIZE as usize)]);
-                        idx_anchor += 1;
-                        data_anchor += PAGE_SIZE as usize;
-                    }
-                } else {
-                    self.device_engine
-                        .clone()
-                        .write(
-                            new_poses[idx_anchor].offset,
-                            new_poses[idx_anchor].bid,
-                            &data[data_anchor..(data_anchor + PAGE_SIZE as usize)],
-                        )
-                        .await
-                        .unwrap();
-                    checksum_vec[i + start_page as usize] = Hasher::new()
-                        .checksum(&data[data_anchor..(data_anchor + PAGE_SIZE as usize)]);
-                    idx_anchor += 1;
-                    data_anchor += PAGE_SIZE as usize;
-                }
-            }
-            if end_page as i64 > last_page {
-                for page in last_page + 1..=end_page as i64 {
-                    let mut buf = DmaBuf::alloc((PAGE_SIZE) as usize, 0x1000);
-                    buf.as_mut().fill(0);
-                    if page as u64 == end_page {
-                        let buffer = buf.as_mut();
-                        buffer[0..(data.len() - data_anchor)].copy_from_slice(&data[data_anchor..]);
-                        checksum_vec.push(Hasher::new().checksum(buffer.as_ref()));
-                        self.device_engine
-                            .clone()
-                            .write(
-                                new_poses[idx_anchor].offset,
-                                new_poses[idx_anchor].bid,
-                                buffer,
-                            )
-                            .await
-                            .unwrap();
-                        idx_anchor += 1;
-                        data_anchor = data.len();
-                    } else {
-                        self.device_engine
-                            .clone()
-                            .write(
-                                new_poses[idx_anchor].offset,
-                                new_poses[idx_anchor].bid,
-                                &data[data_anchor..(data_anchor + PAGE_SIZE as usize)],
-                            )
-                            .await
-                            .unwrap();
-                        checksum_vec.push(
-                            Hasher::new()
-                                .checksum(&data[data_anchor..(data_anchor + PAGE_SIZE as usize)]),
-                        );
-                        idx_anchor += 1;
-                        data_anchor += PAGE_SIZE as usize;
-                    }
-                }
-            }
-        })
-        .await;
-        chunk_meta.size = size.max(offset + data.len() as u64);
-        let mut locations = match chunk_meta.location {
-            Some(l) => l.clone(),
-            None => HashMap::new(),
-        };
-        let mut idx = 0;
-        for page in start_page..=end_page {
-            let pos = PagePos {
-                bid: new_poses[idx].bid,
-                offset: new_poses[idx].offset,
-            };
-            locations.insert(page, pos);
-            idx += 1;
-        }
-        chunk_meta.location = Some(locations);
-        chunk_meta.csum_data = checksum_vec;
-        chunk_meta.csum_type = "CRC32".into();
-        self.db
-            .put(name, serde_json::to_string(&chunk_meta).unwrap().as_bytes())
-            .unwrap();
-        Ok(())
-    }
-
-    /// create a new chunk with no space allocated
-    ///
-    /// store default data in RocksDB
-    pub fn create(&self, name: String) -> Result<()> {
-        let db = self.db.clone();
-        let chunk_meta = ChunkMeta::default();
-        db.put(name, serde_json::to_string(&chunk_meta).unwrap().as_bytes())
-            .unwrap();
-        Ok(())
-    }
-
-    /// remove a chunk's metadata from RocksDB
-    ///
-    /// todo: clear global freelist
-    pub fn remove(&self, name: String) -> Result<()> {
-        let db = self.db.clone();
-        db.delete(name).unwrap();
-        Ok(())
-    }
-
-    pub fn stat(&self, name: String) -> Result<StatMeta> {
-        let chunk_meta = self.db.clone().get(name).unwrap();
-        if chunk_meta.is_none() {
-            return Err(EngineError::MetaNotExist);
-        }
-        let chunk_meta: ChunkMeta =
-            serde_json::from_slice(&String::from_utf8(chunk_meta.unwrap()).unwrap().as_bytes())
-                .unwrap();
-        let ret = StatMeta {
-            size: chunk_meta.size,
-            csum_type: chunk_meta.csum_type.clone(),
-        };
-        Ok(ret)
-    }
-
-    pub async fn unload(&self) -> Result<()> {
-        self.device_engine.close_bs().await
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MadEngine {
     // global free list
-    free_list: HashMap<SBlobId, BitMap>,
+    pub free_list: HashMap<SBlobId, BitMap>,
     // allocated blobs
-    blobs: Vec<SBlobId>,
+    pub blobs: Vec<SBlobId>,
     // information about lower device
-    device: DeviceInfo,
+    pub(crate) device: DeviceInfo,
 }
 
 impl MadEngine {
@@ -610,12 +91,12 @@ impl MadEngine {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeviceInfo {
     // cluster size in MB
-    cluster_size: u64,
+    pub(crate) cluster_size: u64,
     // page size in KB
-    page_size: u64,
+    pub(crate) page_size: u64,
     // this should be euqal to page_size
-    io_unit: u64,
-    total_cluster: u64,
+    pub(crate) io_unit: u64,
+    pub(crate) total_cluster: u64,
 }
 
 impl DeviceInfo {
@@ -632,13 +113,13 @@ impl DeviceInfo {
 #[derive(Debug)]
 pub struct ThreadData {
     // allocated blobs in the thread
-    tblobs: Vec<SBlobId>,
+    pub(crate) tblobs: Vec<SBlobId>,
     // self owned free list, can 'steal' others' space
-    tfree_list: HashMap<SBlobId, BitMap>,
+    pub(crate) tfree_list: HashMap<SBlobId, BitMap>,
     // channel: Option<IoChannel>,
-    db: Option<Arc<DB>>,
+    pub(crate) db: Option<Arc<DB>>,
     // bs: Option<Arc<Blobstore>>,
-    handle: Option<Arc<DeviceEngine>>,
+    // handle: Option<Arc<DeviceEngine>>,
 }
 
 impl Default for ThreadData {
@@ -649,11 +130,11 @@ impl Default for ThreadData {
             // channel: None,
             db: None,
             // bs: None,
-            handle: None,
+            // handle: None,
         }
     }
 }
 
 thread_local! {
-    static TLS: RefCell<ThreadData> = RefCell::new(ThreadData::default());
+    pub static TLS: RefCell<ThreadData> = RefCell::new(ThreadData::default());
 }

--- a/mad_engine/src/device_engine.rs
+++ b/mad_engine/src/device_engine.rs
@@ -32,25 +32,25 @@ impl DeviceEngine {
     }
 
     async fn open_bs(name: &str) -> Result<Blobstore> {
-        let mut bs_dev = blob_bdev::BlobStoreBDev::create(name).unwrap();
-        let bs = blob::Blobstore::init(&mut bs_dev).await.unwrap();
+        let mut bs_dev = blob_bdev::BlobStoreBDev::create(name)?;
+        let bs = blob::Blobstore::init(&mut bs_dev).await?;
         Ok(bs)
     }
 
     pub async fn write(&self, offset: u64, blob_id: BlobId, buf: &[u8]) -> Result<()> {
-        let blob = self.bs.open_blob(blob_id).await.unwrap();
-        let channel = self.bs.alloc_io_channel().unwrap();
-        blob.write(&channel, offset, buf).await.unwrap();
-        blob.close().await.unwrap();
+        let blob = self.bs.open_blob(blob_id).await?;
+        let channel = self.bs.alloc_io_channel()?;
+        blob.write(&channel, offset, buf).await?;
+        blob.close().await?;
         drop(channel);
         Ok(())
     }
 
     pub async fn read(&self, offset: u64, blob_id: BlobId, buf: &mut [u8]) -> Result<()> {
-        let blob = self.bs.open_blob(blob_id).await.unwrap();
-        let channel = self.bs.alloc_io_channel().unwrap();
-        blob.read(channel, offset, buf).await.unwrap();
-        blob.close().await.unwrap();
+        let blob = self.bs.open_blob(blob_id).await?;
+        let channel = self.bs.alloc_io_channel()?;
+        blob.read(channel, offset, buf).await?;
+        blob.close().await?;
         // drop(channel);
         Ok(())
     }
@@ -59,16 +59,16 @@ impl DeviceEngine {
     ///
     /// note: size is number of clusters, usually 1MB per cluster
     pub async fn create_blob(&self, size: u64) -> Result<EngineBlob> {
-        let blob_id = self.bs.create_blob().await.unwrap();
-        let blob = self.bs.open_blob(blob_id).await.unwrap();
-        blob.resize(size).await.unwrap();
-        blob.sync_metadata().await.unwrap();
-        blob.close().await.unwrap();
+        let blob_id = self.bs.create_blob().await?;
+        let blob = self.bs.open_blob(blob_id).await?;
+        blob.resize(size).await?;
+        blob.sync_metadata().await?;
+        blob.close().await?;
         Ok(EngineBlob { bl: blob_id })
     }
 
     pub async fn delete_blob(&self, bid: BlobId) -> Result<()> {
-        self.bs.delete_blob(bid).await.unwrap();
+        self.bs.delete_blob(bid).await?;
         Ok(())
     }
 
@@ -76,7 +76,7 @@ impl DeviceEngine {
     ///
     /// todo: check io_channel closed or not
     pub async fn close_bs(&self) -> Result<()> {
-        self.bs.unload().await.unwrap();
+        self.bs.unload().await?;
         Ok(())
     }
 

--- a/mad_engine/src/device_engine.rs
+++ b/mad_engine/src/device_engine.rs
@@ -1,0 +1,97 @@
+use crate::error::Result;
+use async_spdk::blob::{self, BlobId, Blobstore};
+use async_spdk::blob_bdev::{self};
+
+#[derive(Debug)]
+pub struct DeviceEngine {
+    pub bs: Blobstore,
+    pub name: String,
+    pub io_size: u64,
+}
+
+impl DeviceEngine {
+    pub fn get_name(&self) -> Result<String> {
+        Ok(self.name.clone())
+    }
+
+    pub fn get_io_size(&self) -> Result<u64> {
+        Ok(self.io_size)
+    }
+}
+
+impl DeviceEngine {
+    pub async fn new(name: &str) -> Result<Self> {
+        let bs = DeviceEngine::open_bs(name).await?;
+        let size = bs.io_unit_size();
+        let ret = DeviceEngine {
+            bs,
+            name: String::from(name),
+            io_size: size,
+        };
+        Ok(ret)
+    }
+
+    async fn open_bs(name: &str) -> Result<Blobstore> {
+        let mut bs_dev = blob_bdev::BlobStoreBDev::create(name).unwrap();
+        let bs = blob::Blobstore::init(&mut bs_dev).await.unwrap();
+        Ok(bs)
+    }
+
+    pub async fn write(&self, offset: u64, blob_id: BlobId, buf: &[u8]) -> Result<()> {
+        let blob = self.bs.open_blob(blob_id).await.unwrap();
+        let channel = self.bs.alloc_io_channel().unwrap();
+        blob.write(&channel, offset, buf).await.unwrap();
+        blob.close().await.unwrap();
+        drop(channel);
+        Ok(())
+    }
+
+    pub async fn read(&self, offset: u64, blob_id: BlobId, buf: &mut [u8]) -> Result<()> {
+        let blob = self.bs.open_blob(blob_id).await.unwrap();
+        let channel = self.bs.alloc_io_channel().unwrap();
+        blob.read(channel, offset, buf).await.unwrap();
+        blob.close().await.unwrap();
+        // drop(channel);
+        Ok(())
+    }
+
+    /// create a blob with #size clusters
+    ///
+    /// note: size is number of clusters, usually 1MB per cluster
+    pub async fn create_blob(&self, size: u64) -> Result<EngineBlob> {
+        let blob_id = self.bs.create_blob().await.unwrap();
+        let blob = self.bs.open_blob(blob_id).await.unwrap();
+        blob.resize(size).await.unwrap();
+        blob.sync_metadata().await.unwrap();
+        blob.close().await.unwrap();
+        Ok(EngineBlob { bl: blob_id })
+    }
+
+    pub async fn delete_blob(&self, bid: BlobId) -> Result<()> {
+        self.bs.delete_blob(bid).await.unwrap();
+        Ok(())
+    }
+
+    /// close blobstore handle
+    ///
+    /// todo: check io_channel closed or not
+    pub async fn close_bs(&self) -> Result<()> {
+        self.bs.unload().await.unwrap();
+        Ok(())
+    }
+
+    pub fn total_data_cluster_count(&self) -> Result<u64> {
+        Ok(self.bs.total_data_cluster_count())
+    }
+}
+
+#[derive(Debug)]
+pub struct EngineBlob {
+    pub bl: BlobId,
+}
+
+impl EngineBlob {
+    pub fn get_id(&self) -> Result<BlobId> {
+        Ok(self.bl)
+    }
+}

--- a/mad_engine/src/device_engine.rs
+++ b/mad_engine/src/device_engine.rs
@@ -20,8 +20,8 @@ impl DeviceEngine {
 }
 
 impl DeviceEngine {
-    pub async fn new(name: &str) -> Result<Self> {
-        let bs = DeviceEngine::open_bs(name).await?;
+    pub async fn new(name: &str, is_reload: bool) -> Result<Self> {
+        let bs = DeviceEngine::open_bs(name, is_reload).await?;
         let size = bs.io_unit_size();
         let ret = DeviceEngine {
             bs,
@@ -31,9 +31,13 @@ impl DeviceEngine {
         Ok(ret)
     }
 
-    async fn open_bs(name: &str) -> Result<Blobstore> {
+    async fn open_bs(name: &str, is_reload: bool) -> Result<Blobstore> {
         let mut bs_dev = blob_bdev::BlobStoreBDev::create(name)?;
-        let bs = blob::Blobstore::init(&mut bs_dev).await?;
+        let bs = if !is_reload{
+            blob::Blobstore::init(&mut bs_dev).await?
+        }else{
+            blob::Blobstore::load(&mut bs_dev).await?
+        };
         Ok(bs)
     }
 

--- a/mad_engine/src/engine.rs
+++ b/mad_engine/src/engine.rs
@@ -51,7 +51,7 @@ impl MadEngineHandle {
         db: Arc<DBWithThreadMode<SingleThreaded>>,
         device_name: &str,
     ) -> Result<Self> {
-        let handle = Arc::new(DeviceEngine::new(device_name).await.unwrap());
+        let handle = Arc::new(DeviceEngine::new(device_name, true).await.unwrap());
         let pool = ThreadPool::new(NUM_THREAD, NUM_THREAD, Duration::from_secs(1));
         let global = db
             // .get(MAGIC.to_string())
@@ -110,7 +110,7 @@ impl MadEngineHandle {
         db: Arc<DBWithThreadMode<SingleThreaded>>,
         device_name: &str,
     ) -> Result<Self> {
-        let handle = Arc::new(DeviceEngine::new(device_name).await.unwrap());
+        let handle = Arc::new(DeviceEngine::new(device_name, false).await.unwrap());
         let pool = ThreadPool::new(NUM_THREAD, NUM_THREAD, Duration::from_secs(1));
         let total_cluster = handle.total_data_cluster_count().unwrap();
         let num_init = NUM_THREAD;

--- a/mad_engine/src/engine.rs
+++ b/mad_engine/src/engine.rs
@@ -1,98 +1,571 @@
 use crate::error::{EngineError, Result};
-use async_spdk::blob::{self, BlobId, Blobstore};
-use async_spdk::blob_bdev::{self, BlobStoreBDev};
-use std::sync::Arc;
+use crate::utils::*;
+use crate::device_engine::*;
+use crate::common::*;
+use async_spdk::env::DmaBuf;
+use async_spdk::event;
+use log::*;
+use rocksdb::{DBWithThreadMode, SingleThreaded, DB};
+use rusty_pool::ThreadPool;
+use std::time::Duration;
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, Mutex},
+};
 
-#[derive(Debug)]
-pub struct DeviceEngine {
-    pub bs: Blobstore,
-    pub name: String,
-    pub io_size: u64,
+const PAGE_SIZE: u64 = 0x1000;
+
+pub struct MadEngineHandle {
+    db: Arc<DB>,
+    device_engine: Arc<DeviceEngine>,
+    mad_engine: Arc<Mutex<MadEngine>>,
+    pool: ThreadPool,
 }
 
-impl DeviceEngine {
-    pub fn get_name(&self) -> Result<String> {
-        Ok(self.name.clone())
+impl MadEngineHandle {
+    /// create or restore a madengine handle
+    pub async fn new(path: impl AsRef<Path>, device_name: &str) -> Result<Self> {
+        let db = Arc::new(DB::open_default(path).unwrap());
+        if let Some(_) = db
+            .get(Hasher::new().checksum(MAGIC.as_bytes()).to_string())
+            .unwrap()
+        {
+            info!("start to restore metadata");
+            return Self::restore(db, device_name).await;
+        } else {
+            info!("create new engine");
+            return Self::create_me(db.clone(), device_name).await;
+        }
     }
 
-    pub fn get_io_size(&self) -> Result<u64> {
-        Ok(self.io_size)
+    pub async fn restore(
+        db: Arc<DBWithThreadMode<SingleThreaded>>,
+        device_name: &str,
+    ) -> Result<Self> {
+        let handle = Arc::new(DeviceEngine::new(device_name).await.unwrap());
+        let pool = ThreadPool::new(NUM_THREAD, NUM_THREAD, Duration::from_secs(1));
+        let global = db
+            .get(Hasher::new().checksum(MAGIC.as_bytes()).to_string())
+            .unwrap();
+        if global.is_none() {
+            return Err(EngineError::RestoreFail);
+        }
+        let global_meta: MadEngine =
+            serde_json::from_slice(&String::from_utf8(global.unwrap()).unwrap().as_bytes())
+                .unwrap();
+        let mad_engine = Arc::new(Mutex::new(global_meta));
+        let num_init = NUM_THREAD;
+        let num_blobs = {
+            let l = mad_engine.lock().unwrap();
+            l.blobs.len()
+        };
+        for i in 0..num_init {
+            // let handle = handle.clone();
+            let db = db.clone();
+            let me = mad_engine.clone();
+            let mut thread_blobids = vec![];
+            let mut blob2map = HashMap::new();
+            {
+                let l = me.lock().unwrap();
+                let mut id = i;
+                while id < num_blobs {
+                    thread_blobids.push(l.blobs[id]);
+                    blob2map.insert(l.blobs[id], l.free_list.get(&l.blobs[id]).unwrap().clone());
+                    id += num_init;
+                }
+            }
+            pool.spawn(async move {
+                TLS.with(move |f| {
+                    let mut br = f.borrow_mut();
+                    br.tblobs = thread_blobids;
+                    br.tfree_list = blob2map;
+                    br.db = Some(db);
+                });
+            });
+        }
+        pool.join();
+        Ok(Self {
+            db: db.clone(),
+            device_engine: handle,
+            mad_engine,
+            pool,
+        })
     }
-}
 
-impl DeviceEngine {
-    pub async fn new(name: &str) -> Result<Self> {
-        let bs = DeviceEngine::open_bs(name).await?;
-        let size = bs.io_unit_size();
-        let ret = DeviceEngine {
-            bs,
-            name: String::from(name),
-            io_size: size,
+    /// create basic MadEngineHandle
+    pub async fn create_me(
+        db: Arc<DBWithThreadMode<SingleThreaded>>,
+        device_name: &str,
+    ) -> Result<Self> {
+        let handle = Arc::new(DeviceEngine::new(device_name).await.unwrap());
+        let pool = ThreadPool::new(NUM_THREAD, NUM_THREAD, Duration::from_secs(1));
+        let total_cluster = handle.total_data_cluster_count().unwrap();
+        let num_init = NUM_THREAD;
+        let mad_engine = Arc::new(Mutex::new(MadEngine::new(total_cluster)));
+        for _ in 0..num_init {
+            let handle = handle.clone();
+            let blob_id = handle.create_blob(64).await.unwrap();
+            let db = db.clone();
+            let me = mad_engine.clone();
+            // do the initialization work for each thread
+            pool.spawn(async move {
+                TLS.with(move |f| {
+                    let mut br = f.borrow_mut();
+                    br.tblobs = vec![blob_id.get_id().unwrap()];
+                    br.tfree_list = HashMap::new();
+                    let bitmap = BitMap::new(BLOB_SIZE * CLUSTER_SIZE);
+                    br.tfree_list
+                        .insert(blob_id.get_id().unwrap(), bitmap.clone());
+                    let mut l = me.lock().unwrap();
+                    l.blobs.push(blob_id.get_id().unwrap());
+                    l.free_list
+                        .insert(blob_id.get_id().unwrap(), bitmap.clone());
+                    drop(l);
+                    br.db = Some(db);
+                });
+            });
+        }
+        pool.join();
+        let magic = mad_engine.lock().unwrap();
+        let global = magic.clone();
+        drop(magic);
+        db.put(
+            Hasher::new().checksum(MAGIC.as_bytes()).to_string(),
+            serde_json::to_string(&global).unwrap().as_bytes(),
+        )
+        .unwrap();
+        Ok(Self {
+            db: db.clone(),
+            device_engine: handle,
+            mad_engine,
+            pool,
+        })
+    }
+
+    /// read a chunk, this should return the read length
+    ///
+    /// TODO: check read range, return read length
+    pub async fn read(&self, name: String, offset: u64, data: &mut [u8]) -> Result<()> {
+        let len = data.len() as u64;
+        let start_page = offset / PAGE_SIZE;
+        let end_page = (offset + len - 1) / PAGE_SIZE;
+        event::spawn(async {
+            let chunk_meta = self.db.clone().get(name).unwrap();
+            if chunk_meta.is_none() {
+                return Err(EngineError::MetaNotExist);
+            }
+            let chunk_meta: ChunkMeta =
+                serde_json::from_slice(&String::from_utf8(chunk_meta.unwrap()).unwrap().as_bytes())
+                    .unwrap();
+            let size = chunk_meta.size;
+            if offset >= size || offset + len > size {
+                return Err(EngineError::ReadOutRange);
+            }
+            let poses = (start_page..=end_page)
+                .map(|p| {
+                    chunk_meta
+                        .location
+                        .clone()
+                        .unwrap()
+                        .get(&p)
+                        .unwrap()
+                        .clone()
+                })
+                .collect::<Vec<_>>();
+            let checksum_vec = chunk_meta.csum_data.clone();
+            // there should be a merger to merge succesive pages
+            let mut buf = DmaBuf::alloc((PAGE_SIZE) as usize, 0x1000);
+            let mut anchor = 0;
+            for (i, pos) in poses.iter().enumerate() {
+                self.device_engine
+                    .clone()
+                    .read(pos.offset, pos.bid, buf.as_mut())
+                    .await
+                    .unwrap();
+                if Hasher::new().checksum(buf.as_ref()) != checksum_vec[i + start_page as usize] {
+                    return Err(EngineError::CheckSumErr);
+                }
+                if i == poses.len() - 1 {
+                    let end = offset + len - 1 - end_page * PAGE_SIZE;
+                    let buffer = buf.as_ref();
+                    data[anchor..].copy_from_slice(&buffer[0..=end as usize]);
+                } else if i == 0 {
+                    let buffer = buf.as_ref();
+                    data[anchor..((start_page + 1) * PAGE_SIZE - offset) as usize]
+                        .copy_from_slice(&buffer[((offset - start_page * PAGE_SIZE) as usize)..]);
+                    anchor += ((start_page + 1) * PAGE_SIZE - offset) as usize;
+                } else {
+                    data[anchor..(anchor + PAGE_SIZE as usize)].copy_from_slice(&buf.as_ref());
+                    anchor += PAGE_SIZE as usize;
+                }
+            }
+            Ok(())
+        })
+        .await
+        .unwrap();
+        Ok(())
+    }
+
+    pub async fn write(&mut self, name: String, offset: u64, data: &[u8]) -> Result<()> {
+        let len = data.len() as u64;
+        let chunk_meta = self.db.clone().get(name.clone()).unwrap();
+        if chunk_meta.is_none() {
+            return Err(EngineError::MetaNotExist);
+        }
+        let mut chunk_meta: ChunkMeta =
+            serde_json::from_slice(&String::from_utf8(chunk_meta.unwrap()).unwrap().as_bytes())
+                .unwrap();
+        let size = chunk_meta.get_size();
+        if offset >= size {
+            return Err(EngineError::HoleNotAllowed);
+        }
+        let mut checksum_vec = chunk_meta.csum_data.clone();
+        let start_page = offset / PAGE_SIZE;
+        let cover_end_page = size.min(offset + len - 1) / PAGE_SIZE;
+        let end_page = (offset + len - 1) / PAGE_SIZE;
+        let mut last_page = size as i64 / PAGE_SIZE as i64;
+        if size == 0 {
+            last_page = -1;
+        }
+        let total_page_num = end_page - start_page + 1;
+        let global = self
+            .db
+            .get(Hasher::new().checksum(MAGIC.as_bytes()).to_string())
+            .unwrap();
+        if global.is_none() {
+            return Err(EngineError::RestoreFail);
+        }
+        let mut global_meta: MadEngine =
+            serde_json::from_slice(&String::from_utf8(global.unwrap()).unwrap().as_bytes())
+                .unwrap();
+        // let mad_engine = Arc::new(Mutex::new(global_meta));
+        // first write
+        let poses = if size == 0 {
+            vec![]
+        } else {
+            (start_page..=cover_end_page)
+                .map(|p| {
+                    chunk_meta
+                        .location
+                        .clone()
+                        .unwrap()
+                        .get(&p)
+                        .unwrap()
+                        .clone()
+                })
+                .collect::<Vec<_>>()
+        };
+        // get all the new positions to write new data
+        // recycle old positions
+        let poses_copy = poses.clone();
+        let db_copy = self.db.clone();
+        let (new_poses, new_blob2map) = self
+            .pool
+            .complete(async move {
+                let mut ret = vec![];
+                let mut new_blob2map = global_meta.free_list.clone();
+                TLS.with(|f| {
+                    let mut br = f.borrow_mut();
+                    let mut cnt = total_page_num;
+                    while cnt > 0 {
+                        let tblobs = br.tblobs.clone();
+                        for bid in tblobs.iter() {
+                            let bm = br.tfree_list.get_mut(&bid);
+                            if bm.is_none() {
+                                continue;
+                            }
+                            let bm = bm.unwrap();
+                            let idx = bm.find().unwrap();
+                            // here should check full or not
+                            ret.push(PagePos {
+                                bid: bid.clone(),
+                                offset: idx,
+                            });
+                            bm.set(idx);
+                            global_meta.free_list.insert(bid.clone(), bm.clone());
+                            cnt -= 1;
+                            if cnt == 0 {
+                                break;
+                            }
+                        }
+                    }
+                    // recycle old pages
+                    // fix bug: do a merger
+                    let mut new_blobs = vec![];
+                    for pos in poses_copy {
+                        let e = new_blob2map.get_mut(&pos.bid).unwrap();
+                        e.clear(pos.offset);
+                        drop(e);
+                        let mut flag = false;
+                        let tblobs = br.tblobs.clone();
+                        for bid in tblobs.iter() {
+                            if *bid == pos.bid {
+                                let bm = br.tfree_list.get_mut(&bid);
+                                bm.unwrap().clear(pos.offset);
+                                flag = true;
+                                break;
+                            }
+                        }
+                        // not in the old tblobs, but maybe in the newblobs
+                        if flag == false {
+                            for bid in new_blobs.iter() {
+                                if *bid == pos.bid {
+                                    flag = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if flag == false {
+                            new_blobs.push(pos.bid);
+                            let mut bm = BitMap::new_set_ones(BLOB_SIZE * CLUSTER_SIZE);
+                            bm.clear(pos.offset);
+                            br.tfree_list.insert(pos.bid, bm);
+                        } else {
+                            let bm = br.tfree_list.get_mut(&pos.bid).unwrap();
+                            bm.clear(pos.offset);
+                        }
+                    }
+                    for new_blob in new_blobs {
+                        br.tblobs.push(new_blob);
+                    }
+                    global_meta.free_list = new_blob2map.clone();
+                    db_copy.put(
+                        Hasher::new().checksum(MAGIC.as_bytes()).to_string(),
+                        serde_json::to_string(&global_meta.clone()).unwrap().as_bytes(),
+                    )
+                    .unwrap();
+                });
+                (ret, new_blob2map)
+            })
+            .await_complete();
+        let mut l = self.mad_engine.lock().unwrap();
+        l.free_list = new_blob2map;
+        event::spawn(async {
+            let mut idx_anchor = 0;
+            let mut data_anchor = 0;
+            for (i, pos) in poses.iter().enumerate() {
+                let mut buf = DmaBuf::alloc((PAGE_SIZE) as usize, 0x1000);
+                // read first page
+                if i == 0 {
+                    self.device_engine
+                        .clone()
+                        .read(pos.offset, pos.bid, buf.as_mut())
+                        .await
+                        .unwrap();
+                    let buffer = buf.as_mut();
+                    buffer[(offset - start_page * PAGE_SIZE) as usize..].copy_from_slice(
+                        &data
+                            [data_anchor..(PAGE_SIZE - (offset - start_page * PAGE_SIZE)) as usize],
+                    );
+                    checksum_vec[i + start_page as usize] = Hasher::new().checksum(buffer.as_ref());
+                    self.device_engine
+                        .clone()
+                        .write(
+                            new_poses[idx_anchor].offset,
+                            new_poses[idx_anchor].bid,
+                            buffer,
+                        )
+                        .await
+                        .unwrap();
+                    idx_anchor += 1;
+                    data_anchor += (PAGE_SIZE - (offset - start_page * PAGE_SIZE)) as usize;
+                } else if i == poses.len() - 1 {
+                    // all overwrite
+                    if end_page as i64 == last_page {
+                        if size <= offset + len {
+                            let buffer = buf.as_mut();
+                            buffer.fill(0);
+                            buffer[0..(data.len() - data_anchor)]
+                                .copy_from_slice(&data[data_anchor..]);
+                            checksum_vec[i + start_page as usize] =
+                                Hasher::new().checksum(buffer.as_ref());
+                            self.device_engine
+                                .clone()
+                                .write(
+                                    new_poses[idx_anchor].offset,
+                                    new_poses[idx_anchor].bid,
+                                    buffer,
+                                )
+                                .await
+                                .unwrap();
+                            idx_anchor += 1;
+                            data_anchor = data.len();
+                        } else {
+                            self.device_engine
+                                .clone()
+                                .read(pos.offset, pos.bid, buf.as_mut())
+                                .await
+                                .unwrap();
+                            let buffer = buf.as_mut();
+                            buffer[0..(offset + len - end_page * PAGE_SIZE) as usize]
+                                .copy_from_slice(&data[data_anchor..]);
+                            checksum_vec[i + start_page as usize] =
+                                Hasher::new().checksum(buffer.as_ref());
+                            self.device_engine
+                                .clone()
+                                .write(
+                                    new_poses[idx_anchor].offset,
+                                    new_poses[idx_anchor].bid,
+                                    buffer,
+                                )
+                                .await
+                                .unwrap();
+                            idx_anchor += 1;
+                            data_anchor = data.len();
+                        }
+                    } else if last_page > end_page as i64 {
+                        self.device_engine
+                            .clone()
+                            .read(pos.offset, pos.bid, buf.as_mut())
+                            .await
+                            .unwrap();
+                        let buffer = buf.as_mut();
+                        buffer[0..(offset + len - end_page * PAGE_SIZE) as usize]
+                            .copy_from_slice(&data[data_anchor..]);
+                        checksum_vec[i + start_page as usize] =
+                            Hasher::new().checksum(buffer.as_ref());
+                        self.device_engine
+                            .clone()
+                            .write(
+                                new_poses[idx_anchor].offset,
+                                new_poses[idx_anchor].bid,
+                                buffer,
+                            )
+                            .await
+                            .unwrap();
+                        idx_anchor += 1;
+                        data_anchor = data.len();
+                    } else {
+                        self.device_engine
+                            .clone()
+                            .write(
+                                new_poses[idx_anchor].offset,
+                                new_poses[idx_anchor].bid,
+                                &data[data_anchor..(data_anchor + PAGE_SIZE as usize)],
+                            )
+                            .await
+                            .unwrap();
+                        checksum_vec[i + start_page as usize] = Hasher::new()
+                            .checksum(&data[data_anchor..(data_anchor + PAGE_SIZE as usize)]);
+                        idx_anchor += 1;
+                        data_anchor += PAGE_SIZE as usize;
+                    }
+                } else {
+                    self.device_engine
+                        .clone()
+                        .write(
+                            new_poses[idx_anchor].offset,
+                            new_poses[idx_anchor].bid,
+                            &data[data_anchor..(data_anchor + PAGE_SIZE as usize)],
+                        )
+                        .await
+                        .unwrap();
+                    checksum_vec[i + start_page as usize] = Hasher::new()
+                        .checksum(&data[data_anchor..(data_anchor + PAGE_SIZE as usize)]);
+                    idx_anchor += 1;
+                    data_anchor += PAGE_SIZE as usize;
+                }
+            }
+            if end_page as i64 > last_page {
+                for page in last_page + 1..=end_page as i64 {
+                    let mut buf = DmaBuf::alloc((PAGE_SIZE) as usize, 0x1000);
+                    buf.as_mut().fill(0);
+                    if page as u64 == end_page {
+                        let buffer = buf.as_mut();
+                        buffer[0..(data.len() - data_anchor)].copy_from_slice(&data[data_anchor..]);
+                        checksum_vec.push(Hasher::new().checksum(buffer.as_ref()));
+                        self.device_engine
+                            .clone()
+                            .write(
+                                new_poses[idx_anchor].offset,
+                                new_poses[idx_anchor].bid,
+                                buffer,
+                            )
+                            .await
+                            .unwrap();
+                        idx_anchor += 1;
+                        data_anchor = data.len();
+                    } else {
+                        self.device_engine
+                            .clone()
+                            .write(
+                                new_poses[idx_anchor].offset,
+                                new_poses[idx_anchor].bid,
+                                &data[data_anchor..(data_anchor + PAGE_SIZE as usize)],
+                            )
+                            .await
+                            .unwrap();
+                        checksum_vec.push(
+                            Hasher::new()
+                                .checksum(&data[data_anchor..(data_anchor + PAGE_SIZE as usize)]),
+                        );
+                        idx_anchor += 1;
+                        data_anchor += PAGE_SIZE as usize;
+                    }
+                }
+            }
+        })
+        .await;
+        chunk_meta.size = size.max(offset + data.len() as u64);
+        let mut locations = match chunk_meta.location {
+            Some(l) => l.clone(),
+            None => HashMap::new(),
+        };
+        let mut idx = 0;
+        for page in start_page..=end_page {
+            let pos = PagePos {
+                bid: new_poses[idx].bid,
+                offset: new_poses[idx].offset,
+            };
+            locations.insert(page, pos);
+            idx += 1;
+        }
+        chunk_meta.location = Some(locations);
+        chunk_meta.csum_data = checksum_vec;
+        chunk_meta.csum_type = "CRC32".into();
+        self.db
+            .put(name, serde_json::to_string(&chunk_meta).unwrap().as_bytes())
+            .unwrap();
+        Ok(())
+    }
+
+    /// create a new chunk with no space allocated
+    ///
+    /// store default data in RocksDB
+    pub fn create(&self, name: String) -> Result<()> {
+        let db = self.db.clone();
+        let chunk_meta = ChunkMeta::default();
+        db.put(name, serde_json::to_string(&chunk_meta).unwrap().as_bytes())
+            .unwrap();
+        Ok(())
+    }
+
+    /// remove a chunk's metadata from RocksDB
+    ///
+    /// todo: clear global freelist
+    pub fn remove(&self, name: String) -> Result<()> {
+        let db = self.db.clone();
+        db.delete(name).unwrap();
+        Ok(())
+    }
+
+    pub fn stat(&self, name: String) -> Result<StatMeta> {
+        let chunk_meta = self.db.clone().get(name).unwrap();
+        if chunk_meta.is_none() {
+            return Err(EngineError::MetaNotExist);
+        }
+        let chunk_meta: ChunkMeta =
+            serde_json::from_slice(&String::from_utf8(chunk_meta.unwrap()).unwrap().as_bytes())
+                .unwrap();
+        let ret = StatMeta {
+            size: chunk_meta.size,
+            csum_type: chunk_meta.csum_type.clone(),
         };
         Ok(ret)
     }
 
-    async fn open_bs(name: &str) -> Result<Blobstore> {
-        let mut bs_dev = blob_bdev::BlobStoreBDev::create(name).unwrap();
-        let bs = blob::Blobstore::init(&mut bs_dev).await.unwrap();
-        Ok(bs)
-    }
-
-    pub async fn write(&self, offset: u64, blob_id: BlobId, buf: &[u8]) -> Result<()> {
-        let blob = self.bs.open_blob(blob_id).await.unwrap();
-        let channel = self.bs.alloc_io_channel().unwrap();
-        blob.write(&channel, offset, buf).await.unwrap();
-        blob.close().await.unwrap();
-        drop(channel);
-        Ok(())
-    }
-
-    pub async fn read(&self, offset: u64, blob_id: BlobId, buf: &mut [u8]) -> Result<()> {
-        let blob = self.bs.open_blob(blob_id).await.unwrap();
-        let channel = self.bs.alloc_io_channel().unwrap();
-        blob.read(channel, offset, buf).await.unwrap();
-        blob.close().await.unwrap();
-        // drop(channel);
-        Ok(())
-    }
-
-    /// create a blob with #size clusters
-    ///
-    /// note: size is number of clusters, usually 1MB per cluster
-    pub async fn create_blob(&self, size: u64) -> Result<EngineBlob> {
-        let blob_id = self.bs.create_blob().await.unwrap();
-        let blob = self.bs.open_blob(blob_id).await.unwrap();
-        blob.resize(size).await.unwrap();
-        blob.sync_metadata().await.unwrap();
-        blob.close().await.unwrap();
-        Ok(EngineBlob { bl: blob_id })
-    }
-
-    pub async fn delete_blob(&self, bid: BlobId) -> Result<()> {
-        self.bs.delete_blob(bid).await.unwrap();
-        Ok(())
-    }
-
-    /// close blobstore handle
-    ///
-    /// todo: check io_channel closed or not
-    pub async fn close_bs(&self) -> Result<()> {
-        self.bs.unload().await.unwrap();
-        Ok(())
-    }
-
-    pub fn total_data_cluster_count(&self) -> Result<u64> {
-        Ok(self.bs.total_data_cluster_count())
-    }
-}
-
-#[derive(Debug)]
-pub struct EngineBlob {
-    pub bl: BlobId,
-}
-
-impl EngineBlob {
-    pub fn get_id(&self) -> Result<BlobId> {
-        Ok(self.bl)
+    pub async fn unload(&self) -> Result<()> {
+        self.device_engine.close_bs().await
     }
 }

--- a/mad_engine/src/error.rs
+++ b/mad_engine/src/error.rs
@@ -12,6 +12,8 @@ pub enum EngineError {
     ReadOutRange,
     #[error("hole is not allowed")]
     HoleNotAllowed,
+    #[error("restore fail")]
+    RestoreFail,
 }
 
 pub type Result<T> = std::result::Result<T, EngineError>;

--- a/mad_engine/src/error.rs
+++ b/mad_engine/src/error.rs
@@ -1,4 +1,6 @@
+use serde_json::Error;
 use thiserror::Error;
+use async_spdk::SpdkError;
 
 #[derive(Error, Debug)]
 pub enum EngineError {
@@ -14,6 +16,12 @@ pub enum EngineError {
     HoleNotAllowed,
     #[error("restore fail")]
     RestoreFail,
+    #[error("RocksDB Error: {0}")]
+    RocksDBError(#[from] rocksdb::Error),
+    #[error("serde_json Error: {0}")]
+    SerdeJsonError(#[from] serde_json::Error),
+    #[error("spdk Error: {0}")]
+    SPDKError(#[from] SpdkError),
 }
 
 pub type Result<T> = std::result::Result<T, EngineError>;

--- a/mad_engine/src/error.rs
+++ b/mad_engine/src/error.rs
@@ -1,6 +1,6 @@
+use async_spdk::SpdkError;
 use serde_json::Error;
 use thiserror::Error;
-use async_spdk::SpdkError;
 
 #[derive(Error, Debug)]
 pub enum EngineError {
@@ -16,6 +16,8 @@ pub enum EngineError {
     HoleNotAllowed,
     #[error("restore fail")]
     RestoreFail,
+    #[error("fail to get global metadata")]
+    GlobalGetFail,
     #[error("RocksDB Error: {0}")]
     RocksDBError(#[from] rocksdb::Error),
     #[error("serde_json Error: {0}")]

--- a/mad_engine/src/error.rs
+++ b/mad_engine/src/error.rs
@@ -1,5 +1,5 @@
 use async_spdk::SpdkError;
-use serde_json::Error;
+// use serde_json::Error;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/mad_engine/src/lib.rs
+++ b/mad_engine/src/lib.rs
@@ -2,6 +2,8 @@ pub mod common;
 pub use common::*;
 pub mod error;
 pub use error::*;
+pub mod device_engine;
+pub use device_engine::*;
 pub mod engine;
 pub use engine::*;
 

--- a/mad_engine/src/utils.rs
+++ b/mad_engine/src/utils.rs
@@ -12,6 +12,8 @@ pub const BLOB_SIZE: u64 = 64;
 /// cluster size in pages
 pub const CLUSTER_SIZE: u64 = 256;
 
+pub const MAGIC: &str = "MadEngine";
+
 pub struct Hasher {
     ck_sum: Crc<u32>,
 }
@@ -28,7 +30,7 @@ impl Hasher {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct BitMap {
     count: u64,
     words: Vec<u64>,

--- a/mad_engine/src/utils.rs
+++ b/mad_engine/src/utils.rs
@@ -10,7 +10,9 @@ pub const NUM_THREAD: usize = 4;
 /// blob size in MB
 pub const BLOB_SIZE: u64 = 64;
 /// cluster size in pages
-pub const CLUSTER_SIZE: u64 = 256;
+pub const CLUSTER_SIZE_PAGES: u64 = 256;
+/// cluster size in IO_UNIT
+pub const CLUSTER_SIZE: u64 = 256*8;
 
 pub const MAGIC: &str = "MadEngine";
 


### PR DESCRIPTION
- Add restore module, and now old BlobStore can be reload correctly
- Update async_spdk implementation:
    - `read` signature: io_channel -> &io_channel
    - Add `load` function
    - Update submodule version as well.
- io_size used to be a hard-code  number, and this time it is delivered by lower device
- Modify some test module:
    - An example file of real nvme SSD configuration is included in example module
    - Some test arguments are changed due to configuration file changes. This should be fixed by modify hard-code part, so that user can transmit supposed argument in later version.
- Modify ReadMe.md, add test instruction.
- Modify code structure:
    - device_engine.rs: lower blobstore API wrapper
    - engine.rs: specific operation implementation file